### PR TITLE
ES5 support and better error handling

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": ["es2015", "stage-2"],
   "plugins": [
-    ["add-module-exports"],
+    "transform-runtime",
+    "add-module-exports"
   ],
   "env": {
     "test": {

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -5,10 +5,22 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.refreshUserFromIDMService = undefined;
 
+var _assign = require('babel-runtime/core-js/object/assign');
+
+var _assign2 = _interopRequireDefault(_assign);
+
+var _regenerator = require('babel-runtime/regenerator');
+
+var _regenerator2 = _interopRequireDefault(_regenerator);
+
+var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
+
+var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
+
 var refreshUserFromIDMService = exports.refreshUserFromIDMService = function () {
-  var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee(req, res, next) {
+  var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(req, res, next) {
     var skip, query, lgJWT, result, user, dateOfBirth, msg;
-    return regeneratorRuntime.wrap(function _callee$(_context) {
+    return _regenerator2.default.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
@@ -87,8 +99,6 @@ var _utils = require('./utils');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
 function getToken(req) {
   var authHeaderRegex = /^Bearer\s([A-Za-z0-9+\/_\-\.]+)$/;
   var authHeader = req.get('Authorization');
@@ -128,7 +138,7 @@ function extendJWTExpiration(req, res, next) {
         req.lgJWT = token;
         // console.info('Extending JWT expiration.')
         res.set('LearnersGuild-JWT', token);
-        res.cookie('lgJWT', token, Object.assign((0, _utils.cookieOptsJWT)(req), { expires: expires }));
+        res.cookie('lgJWT', token, (0, _assign2.default)((0, _utils.cookieOptsJWT)(req), { expires: expires }));
       } catch (err) {
         console.error('Invalid JWT:', err.message ? err.message : err);
         revokeJWT(req, res);

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -19,7 +19,7 @@ var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
 
 var refreshUserFromIDMService = exports.refreshUserFromIDMService = function () {
   var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(req, res, next) {
-    var skip, query, lgJWT, result, user, dateOfBirth, msg;
+    var skip, query, lgJWT, result, user, dateOfBirth;
     return _regenerator2.default.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
@@ -65,10 +65,15 @@ var refreshUserFromIDMService = exports.refreshUserFromIDMService = function () 
           case 13:
             _context.prev = 13;
             _context.t0 = _context['catch'](0);
-            msg = 'ERROR updating user from IDM service:';
 
-            console.error(msg, _context.t0.stack);
-            return _context.abrupt('return', next(new Error(msg + ' ' + (_context.t0.message || _context.t0))));
+            console.error('ERROR updating user from IDM service:', _context.t0.message ? _context.t0.message : _context.t0);
+
+            if (!next) {
+              _context.next = 18;
+              break;
+            }
+
+            return _context.abrupt('return', next(_context.t0));
 
           case 18:
             if (next) {
@@ -121,6 +126,9 @@ function addUserToRequestFromJWT(req, res, next) {
       }
     } catch (err) {
       console.error('Error getting user from JWT:', err.message ? err.message : err);
+      if (next) {
+        return next(err);
+      }
     }
   }
   if (next) {
@@ -142,6 +150,9 @@ function extendJWTExpiration(req, res, next) {
       } catch (err) {
         console.error('Invalid JWT:', err.message ? err.message : err);
         revokeJWT(req, res);
+        if (next) {
+          return next(err);
+        }
       }
     } else {
       console.log('Inactive User [' + req.user.id + '] (' + req.user.handle + '). Revoking JWT');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,15 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.JWT_ISSUER = undefined;
+
+var _assign = require('babel-runtime/core-js/object/assign');
+
+var _assign2 = _interopRequireDefault(_assign);
+
+var _stringify = require('babel-runtime/core-js/json/stringify');
+
+var _stringify2 = _interopRequireDefault(_stringify);
+
 exports.idmGraphQLFetch = idmGraphQLFetch;
 exports.jwtClaimsForUser = jwtClaimsForUser;
 exports.userFromJWTClaims = userFromJWTClaims;
@@ -34,10 +43,10 @@ function idmGraphQLFetch(graphQLParams) {
       'Content-Type': 'application/json',
       'LearnersGuild-Skip-Update-User-Middleware': 1
     },
-    body: JSON.stringify(graphQLParams)
+    body: (0, _stringify2.default)(graphQLParams)
   };
   if (token) {
-    options.headers = Object.assign(options.headers, {
+    options.headers = (0, _assign2.default)(options.headers, {
       Authorization: 'Bearer ' + token
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/idm-jwt-auth",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Authenticate using JSON web tokens and Learners Guild IDM service.",
   "scripts": {
     "build": "babel -d lib/ src/ --ignore src/__tests__",
@@ -28,15 +28,18 @@
   },
   "license": "UNLICENSED",
   "dependencies": {
+    "babel-runtime": "^6.22.0",
     "isomorphic-fetch": "^2.2.1",
     "jsonwebtoken": "^5.7.0"
   },
   "devDependencies": {
     "ava": "^0.13.0",
-    "babel-cli": "^6.5.1",
-    "babel-plugin-add-module-exports": "^0.1.2",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-preset-stage-2": "^6.5.0",
+    "babel-cli": "^6.22.2",
+    "babel-core": "^6.22.1",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-runtime": "^6.22.0",
+    "babel-preset-es2015": "^6.22.0",
+    "babel-preset-stage-2": "^6.22.0",
     "codeclimate-test-reporter": "^0.3.3",
     "nyc": "^7.1.0",
     "publish": "^0.5.0",

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -24,6 +24,9 @@ export function addUserToRequestFromJWT(req, res, next) {
       }
     } catch (err) {
       console.error('Error getting user from JWT:', err.message ? err.message : err)
+      if (next) {
+        return next(err)
+      }
     }
   }
   if (next) {
@@ -78,9 +81,10 @@ export async function refreshUserFromIDMService(req, res, next) {
       req.user = user.active ? user : null
     }
   } catch (err) {
-    const msg = 'ERROR updating user from IDM service:'
-    console.error(msg, err.stack)
-    return next(new Error(`${msg} ${err.message || err}`))
+    console.error('ERROR updating user from IDM service:', err.message ? err.message : err)
+    if (next) {
+      return next(err)
+    }
   }
   if (next) {
     next()
@@ -101,6 +105,9 @@ export function extendJWTExpiration(req, res, next) {
       } catch (err) {
         console.error('Invalid JWT:', err.message ? err.message : err)
         revokeJWT(req, res)
+        if (next) {
+          return next(err)
+        }
       }
     } else {
       console.log(`Inactive User [${req.user.id}] (${req.user.handle}). Revoking JWT`)


### PR DESCRIPTION
Fixes #13 and [ch326](https://app.clubhouse.io/learnersguild/story/326/idm-jwt-auth-doesn-t-work-out-of-the-box-with-es5-clients).

## Overview

The `transform-runtime` babel plugin was needed for ES5 support.

We also have updated the middlewares to propagate any errors that occur during processing the `next` callback (if it was passed).

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

- upgraded babel-related modules to latest versions
- added `babel-runtime` to `dependencies`
- added `babel-plugin-transform-runtime` to `devDependencies`
- updated `.babelrc` to use `transform-runtime` plugin

## Notes

N/A